### PR TITLE
docs: update license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ For more info, see our [contribution guidelines](./CONTRIBUTING.md).
 [release]: https://github.com/troublecatstudios/unity-package-example/releases
 [release-badge]: https://img.shields.io/github/v/release/troublecatstudios/unity-package-example?style=for-the-badge&logo=github
 
-[license]: ./../../../package/LICENSE.md
+[license]: ./package/LICENSE.md
 [license-badge]: https://img.shields.io/github/license/troublecatstudios/unity-package-example?style=for-the-badge

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -28,5 +28,9 @@ This is the first release of the project example.
 - adds a `./unity-project` folder to hold a development Unity project that is used to build and test the Unity package.
 
 
+### Fixed
+- docs: the main README.md uses the correct path to the `./package/LICENSE.md` file
+
+
 <!--begin_changelog-->
 


### PR DESCRIPTION

- fixes the link to the license in the main README.md.


### Checklist
- [x] `./package/CHANGELOG.md` updated?
- [ ] Has the documentation in `./docs` updated?
