### PR TITLE
ci: build workflow only runs when related files change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,11 @@ name: Build Projects
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - package/**
+      - .github/workflows/build.yaml
+      - .github/build/**
+      - unity-project/**
 
 permissions:
   contents: write

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -30,6 +30,7 @@ This is the first release of the project example.
 
 ### Fixed
 - docs: the main README.md uses the correct path to the `./package/LICENSE.md` file
+- ci: the `build` workflow only runs when related files change.
 
 
 <!--begin_changelog-->


### PR DESCRIPTION

- ci: build workflow only runs when related files change


### Checklist
- [x] `./package/CHANGELOG.md` updated?
- [ ] Has the documentation in `./docs` updated?
