### PR TITLE
docs: github-style callouts render correctly

### DIFF
--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -38,6 +38,7 @@ runs:
         pip install mkdocs-macros-plugin
         pip install mkdocs-glightbox
         pip install mkdocs-include-dir-to-nav
+        pip install markdown-callouts
         pip install pillow cairosvg mike
     - name: Build documentation site (latest)
       if: inputs.update_latest == 'true'

--- a/.github/scripts/mkdocs-mike.dockerfile
+++ b/.github/scripts/mkdocs-mike.dockerfile
@@ -8,9 +8,7 @@ RUN pip install pillow cairosvg mike
 
 WORKDIR /tmp/source
 
-COPY mkdocs.yml     ./mkdocs.yml
-COPY ./docs         /tmp/source/docs
-
-RUN mkdocs -v build
-
 EXPOSE 8000
+
+ENTRYPOINT [ "/bin/sh", "-c" ]
+CMD [ "mike deploy develop" ]

--- a/docs/howto/regenerate-documentation.md
+++ b/docs/howto/regenerate-documentation.md
@@ -4,10 +4,10 @@ You may want to wipe your documentation site and start over. This could be becau
 
 
 1. Check out the site locally
-2. Build the included `mkdocs.dockerfile` image
+2. Build the included `mkdocs-mike.dockerfile` image
 
 ```bash
-docker build -t mkdocs:local -f ./.github/scripts/mkdocs.dockerfile .
+docker build -t mkdocs_mike:local -f ./.github/scripts/mkdocs-mike.dockerfile .
 ```
 
 3. Run the following commands to reset your site
@@ -20,22 +20,22 @@ docker run -it `
     -e GIT_COMMITTER_NAME=ci-bot `
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io `
     -p 8000:8000 `
-    -v ${PWD}:/tmp/source mkdocs:local 'mike delete --all'
+    -v ${PWD}:/tmp/source mkdocs_mike:local 'mike delete --all'
 docker run -it `
     -e GIT_COMMITTER_NAME=ci-bot `
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io `
     -p 8000:8000 `
-    -v ${PWD}:/tmp/source mkdocs:local 'mike deploy develop'
+    -v ${PWD}:/tmp/source mkdocs_mike:local 'mike deploy develop'
 docker run -it `
     -e GIT_COMMITTER_NAME=ci-bot `
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io `
     -p 8000:8000 `
-    -v ${PWD}:/tmp/source mkdocs:local 'mike alias develop latest'
+    -v ${PWD}:/tmp/source mkdocs_mike:local 'mike alias develop latest'
 docker run -it `
     -e GIT_COMMITTER_NAME=ci-bot `
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io `
     -p 8000:8000 `
-    -v ${PWD}:/tmp/source mkdocs:local 'mike set-default latest'
+    -v ${PWD}:/tmp/source mkdocs_mike:local 'mike set-default latest'
 ```
 
 
@@ -47,22 +47,22 @@ docker run -it \
     -e GIT_COMMITTER_NAME=ci-bot \
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io \
     -p 8000:8000 \
-    -v $(PWD):/tmp/source mkdocs:local 'mike delete --all'
+    -v $(PWD):/tmp/source mkdocs_mike:local 'mike delete --all'
 docker run -it \
     -e GIT_COMMITTER_NAME=ci-bot \
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io \
     -p 8000:8000 \
-    -v $(PWD):/tmp/source mkdocs:local 'mike deploy develop'
+    -v $(PWD):/tmp/source mkdocs_mike:local 'mike deploy develop'
 docker run -it \
     -e GIT_COMMITTER_NAME=ci-bot \
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io \
     -p 8000:8000 \
-    -v $(PWD):/tmp/source mkdocs:local 'mike alias develop latest'
+    -v $(PWD):/tmp/source mkdocs_mike:local 'mike alias develop latest'
 docker run -it \
     -e GIT_COMMITTER_NAME=ci-bot \
     -e GIT_COMMITTER_EMAIL=ci-bot@troublecat.io \
     -p 8000:8000 \
-    -v $(PWD):/tmp/source mkdocs:local 'mike set-default latest'
+    -v $(PWD):/tmp/source mkdocs_mike:local 'mike set-default latest'
 ```
 
 These commands will make changes to your `gh-pages` branch locally, but they won't push any of the changes. So make sure you do that at the end.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
+  - callouts
+  - github-callouts
   - md_in_html
   - pymdownx.details
   - tables

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -13,6 +13,7 @@ docs: initial content for changelog management, continuous integration, deployme
 
 ### Fixed
 docs: getting started documentation git flow graph is more readable in dark mode.
+docs: github-style markdown callouts no longer render as block comments.
 
 ### Changed
 ci: `build` workflow only runs if the `Editor` or `Runtime` code files change


### PR DESCRIPTION
fixes #8. Adds the [markdown-callouts](https://github.com/oprypin/markdown-callouts) extension to the mkdocs configuration. This allows [github-style callouts](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) (alerts) to display using the same styling as [admonitions in material for mkdocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).

Here is a screenshot of the fix in place on the example documentation site.

![image](https://github.com/user-attachments/assets/95831c09-d193-409a-99ae-2e57c13f1537)


<!-- Please describe, in as much detail as you can, what your pull request changes.
  Make sure to note what changes if any users might need to make in their application due to this PR? -->


### Checklist
- [x] `./package/CHANGELOG.md` updated?
- [x] Has the documentation in `./docs` updated?
